### PR TITLE
add a font for Linux

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -4,8 +4,8 @@ body {
   margin: 0;
   font-size: 16px;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-    Helvetica Neue, Helvetica, PingFang SC, Hiragino Sans GB, Microsoft YaHei,
-    SimSun, sans-serif;
+    Noto Sans CJK SC, Helvetica Neue, Helvetica, PingFang SC, Hiragino Sans GB,
+    Microsoft YaHei, SimSun, sans-serif;
   background-color: #ffffff;
   color: #212121;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Some Linux distributions (such as Pop_OS! and perhaps Ubuntu) would use
a serif font without the change.